### PR TITLE
task(chores): remove javadoc task from gradle SDK-1041

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,18 +88,18 @@ task sourcesJar(type: Jar) {
     classifier = 'sources'
 }
 
-task javadoc(type: Javadoc) {
+/*task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
+}*/
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
+/*task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
-}
+}*/
 
 artifacts {
-    archives javadocJar
+    //archives javadocJar
     archives sourcesJar
 }
 


### PR DESCRIPTION
Ignores below error by removing javadoc:

```
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ‘:compileDebugJavaWithJavac’.
> Failed to query the value of task ‘:compileDebugJavaWithJavac’ property ‘options.generatedSourceOutputDirectory’.
   > Querying the mapped value of map(java.io.File property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Users/piyush.kukadiya/projects-clevertap/sdks/clevertap-segment/build/generated/ap_generated_sources/debug/out)) org.gradle.api.internal.file.DefaultFilePropertyFactory$ToFileTransformer@569f14b9) before task ‘:compileDebugJavaWithJavac’ has completed is not supported
```