### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # CHANGE LOG
 
-Version 1.4.0 (22 December, 2021)
+Version 1.4.0 (18 January, 2022)
 ===================================
-- *(Supports CleverTap 4.4.0)*  
-- *Removal of  versionName/versionCode from the manifest and Support from the gradle file itself.*
+*(Supports CleverTap 4.4.0)*
 
 Version 1.3.0 (1 December, 2021)
 ===================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+Version 1.4.0 (22 December, 2021)
+===================================
+*(Supports CleverTap 4.4.0)*
+
 Version 1.3.0 (1 December, 2021)
 ===================================
 *(Supports analytics-android 4.10.0 and CleverTap 4.3.1 backing Android 12)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 Version 1.4.0 (22 December, 2021)
 ===================================
-*(Supports CleverTap 4.4.0)*
+- *(Supports CleverTap 4.4.0)*  
+- *Removal of  versionName/versionCode from the manifest and Support from the gradle file itself.*
 
 Version 1.3.0 (1 December, 2021)
 ===================================

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     siteUrl = 'https://github.com/CleverTap/clevertap-segment-android'
     gitUrl = 'https://github.com/CleverTap/clevertap-segment-android.git'
 
-    libraryVersion = '1.3.0'
+    libraryVersion = '1.4.0'
 
 
     licenseName = 'The MIT License (MIT)'
@@ -181,7 +181,7 @@ dependencies {
     compileOnly 'com.segment.analytics.android:analytics:4.10.0'
     compileOnly 'androidx.annotation:annotation:1.2.0'
 
-    implementation 'com.clevertap.android:clevertap-android-sdk:4.3.1'
+    implementation 'com.clevertap.android:clevertap-android-sdk:4.4.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation('org.robolectric:robolectric:4.3.1') {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 31
+        versionCode 10400
+        versionName "1.4.0"
     }
 
     compileOptions {
@@ -68,6 +70,19 @@ android {
 
     testOptions {
         unitTests.returnDefaultValues = true
+    }
+
+    buildTypes {
+        debug{
+            buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")
+            buildConfigField("String","VERSION_NAME","\"${defaultConfig.versionName}\"")
+
+        }
+        release {
+            buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")
+            buildConfigField("String","VERSION_NAME","\"${defaultConfig.versionName}\"")
+            
+        }
     }
 
     libraryVariants.all { variant ->

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -2,8 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.segment.analytics.android.integrations.clevertap"
 
-    android:versionCode="10300"
-    android:versionName="1.3.0">
+    android:versionCode="10400"
+    android:versionName="1.4.0">
+    <!-- note: this will be removed from android manifest.xml and moved to build.gradle file in upcoming releases  -->
 
     <application></application>
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.segment.analytics.android.integrations.clevertap"
-
-    android:versionCode="10400"
-    android:versionName="1.4.0">
-    <!-- note: this will be removed from android manifest.xml and moved to build.gradle file in upcoming releases  -->
-
-    <application></application>
-
+<manifest package="com.segment.analytics.android.integrations.clevertap">
+    <application />
 </manifest>


### PR DESCRIPTION
1.  [task: SDK-1231] update clevertap-segment-android SDK to 1.4.0 and support for clevertap-android-sdk:4.4.0
2.  [enhancement] Removal of versionName/versionCode from the manifest and Support from the gradle file itself.

point 2 should not be affecting the usual build flow but if needed, can be improved or discarded for the current release. more info: https://stackoverflow.com/q/32138225